### PR TITLE
perf(player): Only fetch the JS player when needed

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -76,6 +76,15 @@ pub(crate) async fn get(
             .expect("Recoverable error did not contain streaming data")
     };
 
+    let needs_player = streaming_data
+        .adaptive_formats
+        .iter()
+        .any(|f| f.base.url.is_none());
+
+    if needs_player {
+        client.init_player().await;
+    }
+
     // FIXME: DashManifest/HlsManifest
     Ok(streaming_data
         .adaptive_formats
@@ -131,7 +140,7 @@ impl Stream {
                     serde_urlencoded::from_str(signature_cipher.as_str())
                         .expect("signatureCipher was not urlencoded");
 
-                let signature = client.player.cipher().run(root["s"].clone());
+                let signature = client.player().cipher().run(root["s"].clone());
                 let signature_arg = &root["sp"];
                 let mut url = Url::parse(&root["url"])
                     .expect("signatureCipher url attribute was not a valid URL");

--- a/src/stream/common.rs
+++ b/src/stream/common.rs
@@ -28,7 +28,7 @@ impl Stream {
         } else {
             let res = self
                 .client
-                .client
+                .http
                 .head(self.url())
                 .send()
                 .await?
@@ -46,7 +46,7 @@ impl Stream {
     ) -> crate::Result<impl futures_core::Stream<Item = Result<bytes::Bytes, reqwest::Error>>> {
         Ok(self
             .client
-            .client
+            .http
             .get(self.url())
             .send()
             .await?

--- a/src/youtube/innertube.rs
+++ b/src/youtube/innertube.rs
@@ -37,7 +37,7 @@ pub enum Browse {
 
 #[derive(Debug)]
 pub struct Api {
-    ytcfg: YtCfg,
+    pub(crate) ytcfg: YtCfg,
     http: reqwest::Client,
 }
 


### PR DESCRIPTION
This defers fetching and parsing of the js player, until it is actually needed, e.g. when a stream is missing a `url` but has a `signature_cipher`. Only then the player is fetched, parsed and persisted in the `Client` for future use.