### PR TITLE
feat(streams): Allow for extraction of "level2" videos

### DIFF
--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -30,6 +30,7 @@ define_test!(vr, "-xNN-bJQ4vI");
 define_test!(hdr, "vX2vsvdq8nw");
 define_test!(rating_disabled, "5VGm0dczmHc");
 define_test!(subtitles, "YltHGKX80Y8");
+define_test!(age_restricted, "SkRSXFQerZs");
 
 mod embed_restricted {
     use super::CLIENT;


### PR DESCRIPTION
- Level1 videos can be requested by everyone.
- Level2 videos can only be requested by logged in users and embedded
  clients
- Level3 videos con only be requested by logged in users.

See https://github.com/ATiltedTree/ytextract/issues/26#issuecomment-887798222
