### PR TITLE
test(video/stream): Remove deleted error test

### DIFF
--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -60,7 +60,6 @@ mod error {
         NudityOrSexualContentViolation
     );
     define_test!(account_terminated, "Pfhpe6shO2U", AccountTerminated);
-    define_test!(removed_by_uploader, "MwCXB2byk58", RemovedByUploader);
     define_test!(tos_violation, "tJievCeKBs0", TermsOfServiceViolation);
     define_test!(age_restricted, "SkRSXFQerZs", AgeRestricted);
 

--- a/tests/video.rs
+++ b/tests/video.rs
@@ -165,7 +165,6 @@ mod error {
         NudityOrSexualContentViolation
     );
     define_test!(account_terminated, "Pfhpe6shO2U", AccountTerminated);
-    define_test!(removed_by_uploader, "MwCXB2byk58", RemovedByUploader);
     define_test!(tos_violation, "tJievCeKBs0", TermsOfServiceViolation);
 
     #[async_std::test]


### PR DESCRIPTION
IDs seem to be garbage collected by YouTube
and return to a `NotFound` state

bors r+