### PR TITLE
fix(stream): Include common properties in `Debug`

### DIFF
--- a/src/stream/audio.rs
+++ b/src/stream/audio.rs
@@ -36,6 +36,7 @@ impl Stream {
 impl std::fmt::Debug for Stream {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug = f.debug_struct("AudioStream");
+        self.common.debug(&mut debug);
         self.debug(&mut debug);
         debug.finish()
     }

--- a/src/stream/video.rs
+++ b/src/stream/video.rs
@@ -42,6 +42,7 @@ impl Stream {
 impl std::fmt::Debug for Stream {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug = f.debug_struct("VideoStream");
+        self.common.debug(&mut debug);
         self.debug(&mut debug);
         debug.finish()
     }


### PR DESCRIPTION
Let `AudioStream` and `VideoStream` print common properties in `Debug`

bors r+