### PR TITLE
chore(stream): Remove `Quality`

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -23,7 +23,6 @@ mod video;
 pub use self::audio::Stream as Audio;
 pub use self::common::Stream as Common;
 pub use self::video::Stream as Video;
-pub use crate::youtube::player_response::Quality;
 use crate::{youtube::player_response::FormatType, Client};
 
 pub(crate) async fn get(

--- a/src/stream/common.rs
+++ b/src/stream/common.rs
@@ -1,7 +1,4 @@
-use crate::{
-    youtube::player_response::{CommonFormat, Quality},
-    Client,
-};
+use crate::{youtube::player_response::CommonFormat, Client};
 
 use chrono::{DateTime, Utc};
 use reqwest::Url;
@@ -56,11 +53,6 @@ impl Stream {
             .bytes_stream())
     }
 
-    /// The [`Quality`] of a [`Stream`]
-    pub fn quality(&self) -> &Quality {
-        &self.format.quality
-    }
-
     /// The [mime type](https://en.wikipedia.org/wiki/Media_type) of a [`Stream`]
     pub fn mime_type(&self) -> &str {
         &self.format.mime_type
@@ -84,7 +76,6 @@ impl Stream {
     pub(super) fn debug(&self, debug: &mut std::fmt::DebugStruct<'_, '_>) {
         debug
             .field("url", &self.url())
-            .field("quality", &self.quality())
             .field("mime_type", &self.mime_type())
             .field("last_modified", &self.last_modified())
             .field("bitrate", &self.bitrate())

--- a/src/youtube/player_response.rs
+++ b/src/youtube/player_response.rs
@@ -82,7 +82,6 @@ pub struct Format {
 #[serde(rename_all = "camelCase")]
 pub struct CommonFormat {
     pub url: Url,
-    pub quality: Quality,
     pub mime_type: String,
     #[serde_as(as = "serde_with::TimestampMilliSeconds<String>")]
     pub last_modified: DateTime<Utc>,
@@ -121,23 +120,6 @@ pub struct AudioFormat {
     pub audio_sample_rate: u64,
     pub audio_quality: String,
     pub audio_channels: u64,
-}
-
-/// The quality of a Stream
-#[allow(missing_docs)]
-#[derive(Debug, Deserialize, PartialEq, Eq, Clone, Copy, PartialOrd, Ord)]
-#[serde(rename_all = "lowercase")]
-#[non_exhaustive]
-pub enum Quality {
-    Tiny,
-    Small,
-    Medium,
-    Large,
-
-    HD720,
-    HD1080,
-    HD1440,
-    HD2160,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
All the information `Quality` contained was already available with
`Video`'s `width`, `heigth` and `fps`,
and `Audio`'s `sample_rate` and `bitrate`.

This also removes the need to update the `Quality` enum everytime we
find a new value to add.

bors r+