### PR TITLE
feat: Added Send and Sync traits to Playlist::videos and Video::related.

### DIFF
--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -143,7 +143,7 @@ impl Playlist {
         let contents = self.response.contents.clone();
         let client = self.client.clone();
         async_stream::stream! {
-            let mut videos: Box<dyn Iterator<Item = browse::playlist::PlaylistItem>> =
+            let mut videos: Box<dyn Iterator<Item = browse::playlist::PlaylistItem> + Send + Sync> =
                 Box::new(contents.into_videos());
 
             while let Some(video) = videos.next() {

--- a/src/video.rs
+++ b/src/video.rs
@@ -165,7 +165,7 @@ impl Video {
         let client = self.client.clone();
 
         async_stream::stream! {
-            let mut items: Box<dyn Iterator<Item = next::RelatedItem>> =
+            let mut items: Box<dyn Iterator<Item = next::RelatedItem> + Send + Sync> =
                 Box::new(initial_items.into_iter());
 
             while let Some(item) = items.next() {


### PR DESCRIPTION
### Introduction
Thanks for this great library! I started using it yesterday, and had a small issue, but I figured out a fix with the help of a kind person on the Rust community Discord.

### Issue
Trying to do anything with the videos from a playlist, like this for example:
```rs
let videos = playlist_data.videos().collect::<Vec<_>>().await;
```
results in this massive error:
```
`dyn std::iter::Iterator<Item = ytextract::youtube::browse::playlist::PlaylistItem>` cannot be sent between threads safely
the trait `std::marker::Send` is not implemented for `dyn std::iter::Iterator<Item = ytextract::youtube::browse::playlist::PlaylistItem>`
required because of the requirements on the impl of `std::marker::Send` for `std::ptr::Unique<dyn std::iter::Iterator<Item = ytextract::youtube::browse::playlist::PlaylistItem>>`
required because it appears within the type `for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5> {std::future::ResumeTy, std::boxed::Box<(dyn std::iter::Iterator<Item = ytextract::youtube::browse::playlist::PlaylistItem> + 'r)>, &'s mut std::boxed::Box<(dyn std::iter::Iterator<Item = ytextract::youtube::browse::playlist::PlaylistItem> + 't0)>, std::option::Option<ytextract::youtube::browse::playlist::PlaylistItem>, ytextract::youtube::browse::playlist::PlaylistItem, ytextract::youtube::browse::playlist::PlaylistVideoRenderer, &'t1 mut async_stream::yielder::Sender<std::result::Result<ytextract::playlist::Video, ytextract::playlist::video::Error>>, async_stream::yielder::Sender<std::result::Result<ytextract::playlist::Video, ytextract::playlist::video::Error>>, &'t2 ytextract::Client, ytextract::Client, std::result::Result<ytextract::playlist::Video, ytextract::playlist::video::Error>, impl futures::Future, (), ytextract::youtube::ContinuationItemRenderer, &'t3 ytextract::youtube::innertube::Api, ytextract::youtube::innertube::Api, &'t4 ytextract::youtube::ContinuationItemRenderer, std::string::String, ytextract::youtube::innertube::Browse, impl for<'t5> futures::Future}`
[...]
```
due to `Send` + `Sync` not being implemented for the iterator that the stream inside `Playlist::videos` is consuming.

### Solution
To fix this, I simply added `Send` + `Sync` bounds to that iterator, and a similar one inside `Video::related`.

This was done by simply turning
```rs
let mut videos: Box<dyn Iterator<Item = browse::playlist::PlaylistItem>> = Box::new(contents.into_videos());
```
into
```rs
let mut videos: Box<dyn Iterator<Item = browse::playlist::PlaylistItem> + Send + Sync> = Box::new(contents.into_videos());
```

This fixes my issues, and lets me actually use the stream.