### PR TITLE
fix(video): Set dislikes to zero

### DIFF
--- a/tests/video.rs
+++ b/tests/video.rs
@@ -60,7 +60,8 @@ async fn get() -> Result<(), Box<dyn std::error::Error>> {
     let ratings = video.ratings();
     if let Ratings::Allowed { likes, dislikes } = ratings {
         assert!(likes >= 51_745);
-        assert!(dislikes >= 622);
+        // YouTube currently hides dislikes. Hopefully they will walk back so keeping this here.
+        //assert!(dislikes >= 622);
     } else {
         unreachable!();
     }


### PR DESCRIPTION
YouTube removed the ability to publicly see dislikes. Instead of
removing dislikes entirely, set them to zero to keep backwards
compatibility.

Will be removed entirely in version `0.11.0`.

bors r+