### PR TITLE
fix(playlist): Support links without a subdomain and with mobile subdomain

### DIFF
--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -23,7 +23,9 @@ impl std::str::FromStr for Id {
     type Err = crate::error::Id<0>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        const PREFIXES: &[&str] = &["https://www.youtube.com/playlist?list="];
+        const PREFIXES: &[&str] = &["https://www.youtube.com/playlist?list=",
+                                    "https://youtube.com/playlist?list=",
+                                    "https://m.youtube.com/playlist?list="];
         const ID_PREFIXES: &[&str] = &["PL", "RD", "UL", "UU", "PU", "OL", "LL", "FL", "WL"];
 
         let id = PREFIXES


### PR DESCRIPTION
Fixes an issue where extracting the Id from a playlist URL would return an Err result if the URL is in the form https://youtube.com/playlist?list= or https://m.youtube.com/playlist?list=
This is fixed by adding https://youtube.com/playlist?list= and https://m.youtube.com/playlist?list= to `PREFIXES`. 

