### PR TITLE
youtube/innertube: Increase timeout to 30s

### DIFF
--- a/src/youtube/innertube.rs
+++ b/src/youtube/innertube.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use crate::{youtube::player_response, Error};
 
 const RETRYS: u32 = 5;
-const TIMEOUT: Duration = Duration::from_secs(5);
+const TIMEOUT: Duration = Duration::from_secs(30);
 const DUMP: bool = option_env!("YTEXTRACT_DUMP").is_some();
 const BASE_URL: &str = "https://youtubei.googleapis.com/youtubei/v1";
 const API_KEY: &str = "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8";


### PR DESCRIPTION
YouTube sometimes likes to take it's time when requesting videos in
parallel.

Fixes #77

bors r+