### PR TITLE
reqwest → ureq for HTTP requests (removing OpenSSL dependency)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,9 @@ version = "0.4"
 default-features = false
 features = ["std"]
 
-[dependencies.reqwest]
-version = "0.11"
-features = ["stream", "json"]
+[dependencies.ureq]
+version = "2.4"
+features = ["json"]
 
 [dev-dependencies]
 futures = "0.3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@
 pub enum Error {
     /// A Error that can occur when requesting web content
     #[error("An Error occurred while requesting web content: {0}")]
-    Request(#[from] reqwest::Error),
+    Request(#[from] ureq::Error),
 
     /// A Error reported by YouTube
     #[error(transparent)]

--- a/src/thumbnail.rs
+++ b/src/thumbnail.rs
@@ -1,12 +1,10 @@
-use reqwest::Url;
-
 /// A Thumbnail.
 #[serde_with::serde_as]
 #[derive(Debug, serde::Deserialize, Clone, PartialEq, Eq)]
 pub struct Thumbnail {
     /// The [`Url`] where the [`Thumbnail`] can be found.
     #[serde_as(as = "serde_with::DisplayFromStr")]
-    pub url: Url,
+    pub url: String,
 
     /// The width of the [`Thumbnail`]
     pub width: u64,

--- a/src/youtube/player_response.rs
+++ b/src/youtube/player_response.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use crate::error::Youtube;
-use reqwest::Url;
 use serde::Deserialize;
 
 use super::Thumbnails;
@@ -81,7 +80,7 @@ pub struct Format {
 #[derive(Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CommonFormat {
-    pub url: Url,
+    pub url: String,
     pub mime_type: String,
     pub itag: u64,
     #[serde_as(as = "Option<serde_with::DisplayFromStr>")]


### PR DESCRIPTION
Hi!

I'm glad that such a library exists in rust. A few months ago I tried running the examples but all of them failed with a segmentation fault. GDB told me it was an issue related to OpenSSL, which is usually available as a dynamic library on linux systems; however when compiling rust on an musl-libc linux distribution (such as Alpine Linux), such dynamic loading from rust always fails (see https://github.com/rust-lang/rust/issues/82193 and similar issues).

I waited a bit to see if the problem would solve itself over time but it's didn't, so I forked this crate to remove the dependency on OpenSSL, introduced by `reqwest`, replacing it with `ureq`, a pure-rust HTTPS library.

So here is the result. `ureq` is not asynchronous, so I don't really expect this to be merged. That being said, I'm still convinced it's a good thing to let you know about this and decide.

My real use case behind all this would probably require asynchronous requests so I might update this with another, async-compatible HTTPS crate.

Many thanks for your work on this!