### PR TITLE
chore: Replace async-std with tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,6 @@ futures = "0.3"
 once_cell = "1"
 assert_matches = "1"
 
-[dev-dependencies.async-std]
+[dev-dependencies.tokio]
 version = "1"
-features = ["attributes", "tokio1"]
+features = ["macros", "rt-multi-thread"]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This includes:
 ## Basic Example
 
 ```rust
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Get a Client for making request
     let client = ytextract::Client::new();

--- a/examples/channel.rs
+++ b/examples/channel.rs
@@ -1,6 +1,6 @@
 use futures::StreamExt;
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = ytextract::Client::new();
 

--- a/examples/playlist.rs
+++ b/examples/playlist.rs
@@ -1,6 +1,6 @@
 use futures::StreamExt;
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = ytextract::Client::new();
 

--- a/examples/related.rs
+++ b/examples/related.rs
@@ -1,6 +1,6 @@
 use futures::StreamExt;
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = ytextract::Client::new();
 

--- a/examples/streams.rs
+++ b/examples/streams.rs
@@ -1,4 +1,4 @@
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = ytextract::Client::new();
 

--- a/examples/video.rs
+++ b/examples/video.rs
@@ -1,4 +1,4 @@
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = ytextract::Client::new();
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -3,7 +3,7 @@
 //! # Example
 //!
 //! ```rust
-//! # #[async_std::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let client = ytextract::Client::new();
 //!
 //! let streams = client.streams("nI2e-J6fsuk".parse()?).await?;

--- a/src/video.rs
+++ b/src/video.rs
@@ -10,7 +10,7 @@
 //! # Example
 //!
 //! ```rust
-//! # #[async_std::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let client = ytextract::Client::new();
 //!
 //! let video = client.video("nI2e-J6fsuk".parse()?).await?;

--- a/tests/channel.rs
+++ b/tests/channel.rs
@@ -1,11 +1,9 @@
-use once_cell::sync::Lazy;
-
-static CLIENT: Lazy<ytextract::Client> = Lazy::new(ytextract::Client::new);
+use ytextract::Client;
 
 #[tokio::test]
 async fn get() -> Result<(), Box<dyn std::error::Error>> {
     let id = "UCdktGrgQlqxPsvHo6cHF0Ng".parse()?;
-    let channel = CLIENT.channel(id).await?;
+    let channel = Client::new().channel(id).await?;
 
     assert_eq!(channel.id(), id);
     assert_eq!(channel.name(), "Cooksie");
@@ -24,8 +22,8 @@ async fn get() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn eq() -> Result<(), Box<dyn std::error::Error>> {
     let id = "UCdktGrgQlqxPsvHo6cHF0Ng".parse()?;
-    let channel1 = CLIENT.channel(id).await?;
-    let channel2 = CLIENT.channel(id).await?;
+    let channel1 = Client::new().channel(id).await?;
+    let channel2 = Client::new().channel(id).await?;
 
     assert_eq!(channel1, channel2);
 
@@ -33,7 +31,7 @@ async fn eq() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 mod metadata {
-    use super::CLIENT;
+    use ytextract::Client;
 
     macro_rules! define_test {
         ($fn:ident, $id:literal, $($attr:meta)?) => {
@@ -41,7 +39,7 @@ mod metadata {
             #[tokio::test]
             async fn $fn() -> Result<(), Box<dyn std::error::Error>> {
                 let id: ytextract::channel::Id = $id.parse()?;
-                let channel = CLIENT.channel(id.clone()).await?;
+                let channel = Client::new().channel(id.clone()).await?;
                 assert_eq!(channel.id(), id);
                 Ok(())
             }
@@ -58,7 +56,7 @@ mod metadata {
 }
 
 mod uploads {
-    use super::CLIENT;
+    use ytextract::Client;
 
     macro_rules! define_test {
         ($fn:ident, $id:literal, $($attr:meta)?) => {
@@ -66,7 +64,7 @@ mod uploads {
             #[tokio::test]
             async fn $fn() -> Result<(), Box<dyn std::error::Error>> {
                 let id: ytextract::channel::Id = $id.parse()?;
-                let playlist = CLIENT.playlist(id.uploads()).await?;
+                let playlist = Client::new().playlist(id.uploads()).await?;
                 assert_eq!(playlist.channel().expect("channel").id(), id);
                 Ok(())
             }
@@ -82,14 +80,14 @@ mod uploads {
 }
 
 mod badges {
-    use super::CLIENT;
+    use ytextract::Client;
 
     macro_rules! define_test {
         ($fn:ident, $id:literal, $badge:ident, $($attr:meta)?) => {
             $(#[$attr])?
             #[tokio::test]
             async fn $fn() -> Result<(), Box<dyn std::error::Error>> {
-                let channel = CLIENT.channel($id.parse()?).await?;
+                let channel = Client::new().channel($id.parse()?).await?;
                 assert_eq!(channel.badges().next(), Some(ytextract::channel::Badge::$badge));
                 Ok(())
             }
@@ -105,15 +103,14 @@ mod badges {
 
 mod error {
     use assert_matches::assert_matches;
-
-    use super::CLIENT;
+    use ytextract::Client;
 
     macro_rules! define_test {
         ($fn:ident, $id:literal, $error:ident) => {
             #[tokio::test]
             async fn $fn() -> Result<(), Box<dyn std::error::Error>> {
                 let id = $id.parse()?;
-                let channel = CLIENT.channel(id).await;
+                let channel = Client::new().channel(id).await;
                 assert_matches!(
                     channel,
                     Err(ytextract::Error::Youtube(ytextract::error::Youtube::$error))
@@ -127,14 +124,14 @@ mod error {
 }
 
 mod subscribers {
-    use super::CLIENT;
+    use ytextract::Client;
 
     macro_rules! define_test {
         ($fn:ident, $id:literal, $subscribers:literal) => {
             #[tokio::test]
             async fn $fn() -> Result<(), Box<dyn std::error::Error>> {
                 let id = $id.parse()?;
-                let channel = CLIENT.channel(id).await?;
+                let channel = Client::new().channel(id).await?;
                 assert!(channel.subscribers() >= Some($subscribers));
                 Ok(())
             }
@@ -144,7 +141,7 @@ mod subscribers {
     #[tokio::test]
     async fn zero() -> Result<(), Box<dyn std::error::Error>> {
         let id = "UCZqdX9k5eyv1aO7i2746bXg".parse()?;
-        let channel = CLIENT.channel(id).await?;
+        let channel = Client::new().channel(id).await?;
         assert_eq!(channel.subscribers(), None);
         Ok(())
     }
@@ -152,7 +149,7 @@ mod subscribers {
     #[tokio::test]
     async fn unviewable() -> Result<(), Box<dyn std::error::Error>> {
         let id = "UCgSJ92_7N3_TOHvKxN2yV1w".parse()?;
-        let channel = CLIENT.channel(id).await?;
+        let channel = Client::new().channel(id).await?;
         assert_eq!(channel.subscribers(), None);
         Ok(())
     }

--- a/tests/channel.rs
+++ b/tests/channel.rs
@@ -2,7 +2,7 @@ use once_cell::sync::Lazy;
 
 static CLIENT: Lazy<ytextract::Client> = Lazy::new(ytextract::Client::new);
 
-#[async_std::test]
+#[tokio::test]
 async fn get() -> Result<(), Box<dyn std::error::Error>> {
     let id = "UCdktGrgQlqxPsvHo6cHF0Ng".parse()?;
     let channel = CLIENT.channel(id).await?;
@@ -21,7 +21,7 @@ async fn get() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn eq() -> Result<(), Box<dyn std::error::Error>> {
     let id = "UCdktGrgQlqxPsvHo6cHF0Ng".parse()?;
     let channel1 = CLIENT.channel(id).await?;
@@ -38,7 +38,7 @@ mod metadata {
     macro_rules! define_test {
         ($fn:ident, $id:literal, $($attr:meta)?) => {
             $(#[$attr])?
-            #[async_std::test]
+            #[tokio::test]
             async fn $fn() -> Result<(), Box<dyn std::error::Error>> {
                 let id: ytextract::channel::Id = $id.parse()?;
                 let channel = CLIENT.channel(id.clone()).await?;
@@ -63,7 +63,7 @@ mod uploads {
     macro_rules! define_test {
         ($fn:ident, $id:literal, $($attr:meta)?) => {
             $(#[$attr])?
-            #[async_std::test]
+            #[tokio::test]
             async fn $fn() -> Result<(), Box<dyn std::error::Error>> {
                 let id: ytextract::channel::Id = $id.parse()?;
                 let playlist = CLIENT.playlist(id.uploads()).await?;
@@ -87,7 +87,7 @@ mod badges {
     macro_rules! define_test {
         ($fn:ident, $id:literal, $badge:ident, $($attr:meta)?) => {
             $(#[$attr])?
-            #[async_std::test]
+            #[tokio::test]
             async fn $fn() -> Result<(), Box<dyn std::error::Error>> {
                 let channel = CLIENT.channel($id.parse()?).await?;
                 assert_eq!(channel.badges().next(), Some(ytextract::channel::Badge::$badge));
@@ -110,7 +110,7 @@ mod error {
 
     macro_rules! define_test {
         ($fn:ident, $id:literal, $error:ident) => {
-            #[async_std::test]
+            #[tokio::test]
             async fn $fn() -> Result<(), Box<dyn std::error::Error>> {
                 let id = $id.parse()?;
                 let channel = CLIENT.channel(id).await;
@@ -131,7 +131,7 @@ mod subscribers {
 
     macro_rules! define_test {
         ($fn:ident, $id:literal, $subscribers:literal) => {
-            #[async_std::test]
+            #[tokio::test]
             async fn $fn() -> Result<(), Box<dyn std::error::Error>> {
                 let id = $id.parse()?;
                 let channel = CLIENT.channel(id).await?;
@@ -141,7 +141,7 @@ mod subscribers {
         };
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn zero() -> Result<(), Box<dyn std::error::Error>> {
         let id = "UCZqdX9k5eyv1aO7i2746bXg".parse()?;
         let channel = CLIENT.channel(id).await?;
@@ -149,7 +149,7 @@ mod subscribers {
         Ok(())
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn unviewable() -> Result<(), Box<dyn std::error::Error>> {
         let id = "UCgSJ92_7N3_TOHvKxN2yV1w".parse()?;
         let channel = CLIENT.channel(id).await?;

--- a/tests/playlist.rs
+++ b/tests/playlist.rs
@@ -3,7 +3,7 @@ use once_cell::sync::Lazy;
 
 static CLIENT: Lazy<ytextract::Client> = Lazy::new(ytextract::Client::new);
 
-#[async_std::test]
+#[tokio::test]
 async fn get() -> Result<(), Box<dyn std::error::Error>> {
     let playlist = CLIENT
         .playlist("PLCSusC_jlo14BH5hHnOh9b0O18HtGT3eP".parse()?)
@@ -28,7 +28,7 @@ async fn get() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn eq() -> Result<(), Box<dyn std::error::Error>> {
     let playlist1 = CLIENT
         .playlist("PLCSusC_jlo15M6x0Ot8gznM-QA8CriNk4".parse()?)
@@ -42,7 +42,7 @@ async fn eq() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn eq_channel() -> Result<(), Box<dyn std::error::Error>> {
     let playlist = CLIENT
         .playlist("PLCSusC_jlo15M6x0Ot8gznM-QA8CriNk4".parse()?)
@@ -53,7 +53,7 @@ async fn eq_channel() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn video() -> Result<(), Box<dyn std::error::Error>> {
     let playlist = CLIENT
         .playlist("PLCSusC_jlo14F22jss8ZtDLbpmRQIVLzr".parse()?)
@@ -86,7 +86,7 @@ mod metadata {
     macro_rules! define_test {
         ($fn:ident, $id:literal, $($attr:meta)?) => {
             $(#[$attr])?
-            #[async_std::test]
+            #[tokio::test]
             async fn $fn() -> Result<(), Box<dyn std::error::Error>> {
                 let id: ytextract::playlist::Id = $id.parse()?;
                 let playlist = CLIENT.playlist(id.clone()).await?;
@@ -111,7 +111,7 @@ mod videos {
     macro_rules! define_test {
         ($fn:ident, $id:literal, $($attr:meta)?) => {
             $(#[$attr])?
-            #[async_std::test]
+            #[tokio::test]
             async fn $fn() -> Result<(), Box<dyn std::error::Error>> {
                 let id = $id.parse()?;
                 let playlist = CLIENT.playlist(id).await?;
@@ -142,7 +142,7 @@ mod error {
 
     macro_rules! define_test {
         ($fn:ident, $id:literal, $error:ident) => {
-            #[async_std::test]
+            #[tokio::test]
             async fn $fn() -> Result<(), Box<dyn std::error::Error>> {
                 let id = $id.parse()?;
                 assert_matches!(
@@ -159,7 +159,7 @@ mod error {
     define_test!(private, "PLCSusC_jlo16bxXlQLScDy4kgdLhhQP8A", NotFound);
     define_test!(deleted, "PLCSusC_jlo16qHzHLY6jmCWG_ov7R2hMv", NotFound);
 
-    #[async_std::test]
+    #[tokio::test]
     async fn video() -> Result<(), Box<dyn std::error::Error>> {
         let playlist = CLIENT
             .playlist("PLCSusC_jlo146Bv2QRvW7jvV0wZYiSf8N".parse()?)

--- a/tests/playlist.rs
+++ b/tests/playlist.rs
@@ -1,11 +1,9 @@
 use futures::StreamExt;
-use once_cell::sync::Lazy;
-
-static CLIENT: Lazy<ytextract::Client> = Lazy::new(ytextract::Client::new);
+use ytextract::Client;
 
 #[tokio::test]
 async fn get() -> Result<(), Box<dyn std::error::Error>> {
-    let playlist = CLIENT
+    let playlist = Client::new()
         .playlist("PLCSusC_jlo14BH5hHnOh9b0O18HtGT3eP".parse()?)
         .await?;
 
@@ -30,10 +28,10 @@ async fn get() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test]
 async fn eq() -> Result<(), Box<dyn std::error::Error>> {
-    let playlist1 = CLIENT
+    let playlist1 = Client::new()
         .playlist("PLCSusC_jlo15M6x0Ot8gznM-QA8CriNk4".parse()?)
         .await?;
-    let playlist2 = CLIENT
+    let playlist2 = Client::new()
         .playlist("PLCSusC_jlo15M6x0Ot8gznM-QA8CriNk4".parse()?)
         .await?;
 
@@ -44,7 +42,7 @@ async fn eq() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test]
 async fn eq_channel() -> Result<(), Box<dyn std::error::Error>> {
-    let playlist = CLIENT
+    let playlist = Client::new()
         .playlist("PLCSusC_jlo15M6x0Ot8gznM-QA8CriNk4".parse()?)
         .await?;
 
@@ -55,7 +53,7 @@ async fn eq_channel() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test]
 async fn video() -> Result<(), Box<dyn std::error::Error>> {
-    let playlist = CLIENT
+    let playlist = Client::new()
         .playlist("PLCSusC_jlo14F22jss8ZtDLbpmRQIVLzr".parse()?)
         .await?;
 
@@ -81,15 +79,16 @@ async fn video() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 mod metadata {
-    use super::CLIENT;
+    use ytextract::Client;
 
     macro_rules! define_test {
         ($fn:ident, $id:literal, $($attr:meta)?) => {
             $(#[$attr])?
             #[tokio::test]
             async fn $fn() -> Result<(), Box<dyn std::error::Error>> {
+                let client = Client::new();
                 let id: ytextract::playlist::Id = $id.parse()?;
-                let playlist = CLIENT.playlist(id.clone()).await?;
+                let playlist = client.playlist(id.clone()).await?;
                 assert_eq!(playlist.id(), id);
                 Ok(())
             }
@@ -105,16 +104,17 @@ mod metadata {
 }
 
 mod videos {
-    use super::CLIENT;
     use futures::stream::StreamExt;
+    use ytextract::Client;
 
     macro_rules! define_test {
         ($fn:ident, $id:literal, $($attr:meta)?) => {
             $(#[$attr])?
             #[tokio::test]
             async fn $fn() -> Result<(), Box<dyn std::error::Error>> {
+                let client = Client::new();
                 let id = $id.parse()?;
-                let playlist = CLIENT.playlist(id).await?;
+                let playlist = client.playlist(id).await?;
                 let videos = playlist.videos();
                 futures::pin_mut!(videos);
                 assert!(videos.next().await.is_some());
@@ -137,16 +137,16 @@ mod videos {
 mod error {
     use assert_matches::assert_matches;
     use futures::StreamExt;
-
-    use super::CLIENT;
+    use ytextract::Client;
 
     macro_rules! define_test {
         ($fn:ident, $id:literal, $error:ident) => {
             #[tokio::test]
             async fn $fn() -> Result<(), Box<dyn std::error::Error>> {
+                let client = Client::new();
                 let id = $id.parse()?;
                 assert_matches!(
-                    CLIENT.playlist(id).await,
+                    client.playlist(id).await,
                     Err(ytextract::Error::Youtube(ytextract::error::Youtube::$error))
                 );
                 Ok(())
@@ -161,7 +161,7 @@ mod error {
 
     #[tokio::test]
     async fn video() -> Result<(), Box<dyn std::error::Error>> {
-        let playlist = CLIENT
+        let playlist = Client::new()
             .playlist("PLCSusC_jlo146Bv2QRvW7jvV0wZYiSf8N".parse()?)
             .await?;
         use ytextract::playlist::video::UnavailabilityReason;

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -5,7 +5,7 @@ static CLIENT: Lazy<ytextract::Client> = Lazy::new(ytextract::Client::new);
 macro_rules! define_test {
     ($fn:ident, $id:literal, $($attr:meta)?) => {
         $(#[$attr])?
-        #[async_std::test]
+        #[tokio::test]
         async fn $fn() -> Result<(), Box<dyn std::error::Error>> {
             let id = $id.parse()?;
             let mut streams = CLIENT.streams(id).await?;
@@ -41,7 +41,7 @@ mod error {
 
     macro_rules! define_test {
         ($fn:ident, $id:literal, $error:ident) => {
-            #[async_std::test]
+            #[tokio::test]
             async fn $fn() -> Result<(), Box<dyn std::error::Error>> {
                 let id = $id.parse()?;
                 assert_matches!(
@@ -64,7 +64,7 @@ mod error {
     define_test!(account_terminated, "Pfhpe6shO2U", AccountTerminated);
     define_test!(age_restricted, "SkRSXFQerZs", AgeRestricted);
 
-    #[async_std::test]
+    #[tokio::test]
     async fn copyright_claim() -> Result<(), Box<dyn std::error::Error>> {
         let id = "6MNavkSGntQ".parse()?;
 

--- a/tests/video.rs
+++ b/tests/video.rs
@@ -1,12 +1,10 @@
 use futures::StreamExt;
-use once_cell::sync::Lazy;
 use ytextract::video::Ratings;
-
-static CLIENT: Lazy<ytextract::Client> = Lazy::new(ytextract::Client::new);
+use ytextract::Client;
 
 #[tokio::test]
 async fn get() -> Result<(), Box<dyn std::error::Error>> {
-    let video = CLIENT
+    let video = Client::new()
         .video("https://www.youtube.com/watch?v=7B2PIVSWtJA".parse()?)
         .await?;
 
@@ -79,8 +77,8 @@ async fn get() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test]
 async fn eq() -> Result<(), Box<dyn std::error::Error>> {
-    let video1 = CLIENT.video("7B2PIVSWtJA".parse()?).await?;
-    let video2 = CLIENT.video("7B2PIVSWtJA".parse()?).await?;
+    let video1 = Client::new().video("7B2PIVSWtJA".parse()?).await?;
+    let video2 = Client::new().video("7B2PIVSWtJA".parse()?).await?;
 
     assert_eq!(video1, video2);
 
@@ -89,8 +87,8 @@ async fn eq() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test]
 async fn eq_channel() -> Result<(), Box<dyn std::error::Error>> {
-    let video1 = CLIENT.video("7B2PIVSWtJA".parse()?).await?;
-    let video2 = CLIENT.video("7B2PIVSWtJA".parse()?).await?;
+    let video1 = Client::new().video("7B2PIVSWtJA".parse()?).await?;
+    let video2 = Client::new().video("7B2PIVSWtJA".parse()?).await?;
 
     assert_eq!(video1.channel(), video2.channel());
 
@@ -99,21 +97,21 @@ async fn eq_channel() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test]
 async fn ratings_not_allowed() -> Result<(), Box<dyn std::error::Error>> {
-    let video = CLIENT.video("9Jg_Fwc0QOY".parse()?).await?;
+    let video = Client::new().video("9Jg_Fwc0QOY".parse()?).await?;
     assert_eq!(video.ratings(), Ratings::NotAllowed);
 
     Ok(())
 }
 
 mod metadata {
-    use super::CLIENT;
+    use ytextract::Client;
 
     macro_rules! define_test {
         ($fn:ident, $id:literal) => {
             #[tokio::test]
             async fn $fn() -> Result<(), Box<dyn std::error::Error>> {
                 let id = $id.parse()?;
-                let video = CLIENT.video(id).await?;
+                let video = Client::new().video(id).await?;
                 assert_eq!(video.id(), id);
                 Ok(())
             }
@@ -134,7 +132,7 @@ mod metadata {
     define_test!(premire, "vv-Fqm6Qtj4");
 
     mod embed_restricted {
-        use super::CLIENT;
+        use ytextract::Client;
 
         define_test!(youtube, "_kmeFXjjGfk");
         define_test!(author, "MeJVWBSsPAY");
@@ -144,8 +142,7 @@ mod metadata {
 
 mod error {
     use assert_matches::assert_matches;
-
-    use super::CLIENT;
+    use ytextract::Client;
 
     macro_rules! define_test {
         ($fn:ident, $id:literal, $error:ident) => {
@@ -153,7 +150,7 @@ mod error {
             async fn $fn() -> Result<(), Box<dyn std::error::Error>> {
                 let id = $id.parse()?;
                 assert_matches!(
-                    CLIENT.video(id).await,
+                    Client::new().video(id).await,
                     Err(ytextract::Error::Youtube(ytextract::error::Youtube::$error))
                 );
                 Ok(())
@@ -186,7 +183,7 @@ mod error {
         let id = "6MNavkSGntQ".parse()?;
 
         assert_matches!(
-            CLIENT.video(id).await,
+            Client::new().video(id).await,
             Err(ytextract::Error::Youtube(ytextract::error::Youtube::CopyrightClaim {
                 claiment,
             })) if claiment == "Richard DiBacco"
@@ -199,7 +196,7 @@ mod error {
 async fn related() -> Result<(), Box<dyn std::error::Error>> {
     let id = "9bZkp7q19f0".parse()?;
 
-    let video = CLIENT.video(id).await?;
+    let video = Client::new().video(id).await?;
 
     video
         .related()

--- a/tests/video.rs
+++ b/tests/video.rs
@@ -4,7 +4,7 @@ use ytextract::video::Ratings;
 
 static CLIENT: Lazy<ytextract::Client> = Lazy::new(ytextract::Client::new);
 
-#[async_std::test]
+#[tokio::test]
 async fn get() -> Result<(), Box<dyn std::error::Error>> {
     let video = CLIENT
         .video("https://www.youtube.com/watch?v=7B2PIVSWtJA".parse()?)
@@ -77,7 +77,7 @@ async fn get() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn eq() -> Result<(), Box<dyn std::error::Error>> {
     let video1 = CLIENT.video("7B2PIVSWtJA".parse()?).await?;
     let video2 = CLIENT.video("7B2PIVSWtJA".parse()?).await?;
@@ -87,7 +87,7 @@ async fn eq() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn eq_channel() -> Result<(), Box<dyn std::error::Error>> {
     let video1 = CLIENT.video("7B2PIVSWtJA".parse()?).await?;
     let video2 = CLIENT.video("7B2PIVSWtJA".parse()?).await?;
@@ -97,7 +97,7 @@ async fn eq_channel() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn ratings_not_allowed() -> Result<(), Box<dyn std::error::Error>> {
     let video = CLIENT.video("9Jg_Fwc0QOY".parse()?).await?;
     assert_eq!(video.ratings(), Ratings::NotAllowed);
@@ -110,7 +110,7 @@ mod metadata {
 
     macro_rules! define_test {
         ($fn:ident, $id:literal) => {
-            #[async_std::test]
+            #[tokio::test]
             async fn $fn() -> Result<(), Box<dyn std::error::Error>> {
                 let id = $id.parse()?;
                 let video = CLIENT.video(id).await?;
@@ -149,7 +149,7 @@ mod error {
 
     macro_rules! define_test {
         ($fn:ident, $id:literal, $error:ident) => {
-            #[async_std::test]
+            #[tokio::test]
             async fn $fn() -> Result<(), Box<dyn std::error::Error>> {
                 let id = $id.parse()?;
                 assert_matches!(
@@ -181,7 +181,7 @@ mod error {
         CommunityGuidelineViolation
     );
 
-    #[async_std::test]
+    #[tokio::test]
     async fn copyright_claim() -> Result<(), Box<dyn std::error::Error>> {
         let id = "6MNavkSGntQ".parse()?;
 
@@ -195,7 +195,7 @@ mod error {
     }
 }
 
-#[async_std::test]
+#[tokio::test]
 async fn related() -> Result<(), Box<dyn std::error::Error>> {
     let id = "9bZkp7q19f0".parse()?;
 


### PR DESCRIPTION
reqwest already depends on tokio, so async-std is just another dependency we can avoid