### PR TITLE
feat(video): Replace `ratings` with `likes`

### DIFF
--- a/src/video.rs
+++ b/src/video.rs
@@ -98,21 +98,15 @@ impl Video {
         self.player_response.video_details.view_count
     }
 
-    /// The [`Ratings`] a [`Video`] received.
-    pub fn ratings(&self) -> Ratings {
-        if let Some((likes, dislikes)) = self
-            .initial_data
+    /// The amount of likes a [`Video`] received.
+    pub fn likes(&self) -> Option<u64> {
+        self.initial_data
             .contents
             .two_column_watch_next_results
             .results
             .results
             .primary()
-            .ratings()
-        {
-            Ratings::Allowed { likes, dislikes }
-        } else {
-            Ratings::NotAllowed
-        }
+            .likes()
     }
 
     /// The hashtags a [`Video`] is tagged with.
@@ -219,7 +213,7 @@ impl std::fmt::Debug for Video {
             .field("channel", &self.channel())
             .field("description", &self.description())
             .field("views", &self.views())
-            .field("ratings", &self.ratings())
+            .field("likes", &self.likes())
             .field("live", &self.live())
             .field("thumbnails", &self.thumbnails())
             .field("date", &self.date())
@@ -289,21 +283,6 @@ impl<'a> PartialEq for Channel<'a> {
 }
 
 impl<'a> Eq for Channel<'a> {}
-
-/// Ratings on a video
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum Ratings {
-    /// Rating is allowed
-    Allowed {
-        /// The amount of likes a [`Video`] received
-        likes: u64,
-        /// The amount of dislikes a [`Video`] received
-        dislikes: u64,
-    },
-
-    /// Rating is not allowed
-    NotAllowed,
-}
 
 define_id! {
     11,

--- a/src/youtube/next.rs
+++ b/src/youtube/next.rs
@@ -87,7 +87,7 @@ pub struct VideoPrimaryInfoRenderer {
 }
 
 impl VideoPrimaryInfoRenderer {
-    pub fn ratings(&self) -> Option<(u64, u64)> {
+    pub fn likes(&self) -> Option<u64> {
         // `like this video along with 4,457 other people` or `I like this`
         let label = &self
             .video_actions
@@ -106,10 +106,7 @@ impl VideoPrimaryInfoRenderer {
             .parse()
             .expect("Likes we not parsable as a unsigned integer");
 
-        // TODO: remove `ratings()` and replace it with `likes()` with v0.11.0
-        let dislikes = 0;
-
-        Some((likes, dislikes))
+        Some(likes)
     }
 
     pub fn hashtags(&self) -> impl Iterator<Item = &str> {

--- a/tests/video.rs
+++ b/tests/video.rs
@@ -1,5 +1,4 @@
 use futures::StreamExt;
-use ytextract::video::Ratings;
 use ytextract::Client;
 
 #[tokio::test]
@@ -54,16 +53,7 @@ async fn get() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(channel.id(), channel.upgrade().await?.id());
     assert!(!video.description().is_empty());
     assert!(video.views() >= 1_068_917);
-
-    let ratings = video.ratings();
-    if let Ratings::Allowed { likes, dislikes } = ratings {
-        assert!(likes >= 51_745);
-        // YouTube currently hides dislikes. Hopefully they will walk back so keeping this here.
-        //assert!(dislikes >= 622);
-    } else {
-        unreachable!();
-    }
-
+    assert!(video.likes() >= Some(51_745));
     assert!(!video.live());
     assert!(!video.thumbnails().is_empty());
     assert_eq!(video.date(), chrono::NaiveDate::from_ymd(2021, 4, 14));
@@ -96,9 +86,9 @@ async fn eq_channel() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[tokio::test]
-async fn ratings_not_allowed() -> Result<(), Box<dyn std::error::Error>> {
+async fn likes_not_allowed() -> Result<(), Box<dyn std::error::Error>> {
     let video = Client::new().video("9Jg_Fwc0QOY".parse()?).await?;
-    assert_eq!(video.ratings(), Ratings::NotAllowed);
+    assert_eq!(video.likes(), None);
 
     Ok(())
 }


### PR DESCRIPTION
For a long time now YouTube no longer provides a dislike count, so remove it
from this library as well.