### PR TITLE
Fix video date parsing when streamed live

### DIFF
--- a/src/video.rs
+++ b/src/video.rs
@@ -23,7 +23,7 @@
 pub mod related;
 
 use crate::{
-    youtube::{innertube::Next, next, parse_date, player_response::PlayerResponse},
+    youtube::{innertube::Next, next, player_response::PlayerResponse},
     Client, Stream, Thumbnail,
 };
 
@@ -133,17 +133,14 @@ impl Video {
 
     /// The date a [`Video`] was published.
     pub fn date(&self) -> chrono::NaiveDate {
-        parse_date(
-            &self
-                .initial_data
-                .contents
-                .two_column_watch_next_results
-                .results
-                .results
-                .primary()
-                .date_text,
-        )
-        .expect("Unable to parse date")
+        self
+            .initial_data
+            .contents
+            .two_column_watch_next_results
+            .results
+            .results
+            .primary()
+            .date()
     }
 
     /// The [`Items`](Related) related to a [`Video`].

--- a/src/youtube/next.rs
+++ b/src/youtube/next.rs
@@ -1,6 +1,8 @@
+use std::ops::Deref;
+
 use super::{
-    parse_subscribers, Badge, ChannelNameRuns, ContinuationItemRenderer, SimpleText, Text,
-    Thumbnails, TitleRun,
+    parse_date, parse_subscribers, Badge, ChannelNameRuns, ContinuationItemRenderer, SimpleText,
+    Text, Thumbnails, TitleRun,
 };
 use serde::Deserialize;
 
@@ -87,6 +89,15 @@ pub struct VideoPrimaryInfoRenderer {
 }
 
 impl VideoPrimaryInfoRenderer {
+    pub fn date(&self) -> chrono::NaiveDate {
+        let date_str = self
+            .date_text
+            .deref()
+            .trim_start_matches("Streamed live on ");
+
+        parse_date(date_str).expect("Unable to parse date")
+    }
+
     pub fn likes(&self) -> Option<u64> {
         // `like this video along with 4,457 other people` or `I like this`
         let label = &self


### PR DESCRIPTION
If a video has been streamed live, its date is prefixed with the text "Streamed live on " which will make the parsing fail. This fixes the issue by removing the prefix if present.

It also moves the date parsing to a separate `date` method on `VideoPrimaryInfoRenderer` (to make it similar to `likes` and `hashtags`).